### PR TITLE
Add serverless FRED proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,15 @@ The script in `index.html` fetches the data on page load and builds the table ro
 
 ## Market Data
 
-The report can also display market indicators sourced from the Federal Reserve's FRED service. To enable this feature you need a FRED API key. Register for a key at [fred.stlouisfed.org](https://fred.stlouisfed.org/). Once obtained, set the value of `API_CONFIG.FRED_API_KEY` in `index.html`.
+The report can also display market indicators sourced from the Federal Reserve's FRED service. Requests are proxied through a Netlify Function so the API key can remain private. Deploy this repository to Netlify and set an environment variable named `FRED_API_KEY` with your key.
 
-Because the FRED API does not send the required CORS headers, the request must be proxied through a small serverless function. Host a simple endpoint (for example with Netlify Functions or Vercel) that forwards the request to FRED and returns the JSON response. Update `fetchMarketData` to call this proxy path (e.g. `/api/fred`).
+The proxy lives at `netlify/functions/fred.js` and forwards any query string it receives to the FRED API while appending the key. Once deployed, the client simply calls `/api/fred?series_id=DGS10` and no key is exposed in `index.html`.
+
+### Deploying the FRED proxy
+
+1. Create a new site on Netlify and connect this repository.
+2. In **Site settings → Environment variables**, add `FRED_API_KEY` with your FRED key.
+3. Deploy the site. Requests to `/api/fred` will be served by the function defined in `netlify/functions/fred.js`.
 
 
 # bank-cre-exposure

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
             UBPR_BASE_URL: 'https://api.ffiec.gov/public/v2/ubpr/financials',
 
             // Federal Reserve Economic Data API
-            FRED_API_KEY: 'YOUR_FRED_API_KEY_HERE', // Replace with actual API key
+            // FRED_API_KEY stored on the server side via Netlify Function
             FRED_BASE_URL: 'https://api.stlouisfed.org/fred'
             // Using live data; no mock values included
         };
@@ -625,7 +625,7 @@
         async function fetchMarketData() {
             try {
                 // Call serverless proxy to avoid FRED CORS restrictions
-                const url = `/api/fred?series_id=DGS10&api_key=${API_CONFIG.FRED_API_KEY}`;
+                const url = `/api/fred?series_id=DGS10`;
                 const response = await fetch(url);
                 if (!response.ok) throw new Error('FRED request failed');
                 const json = await response.json();

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200

--- a/netlify/functions/fred.js
+++ b/netlify/functions/fred.js
@@ -1,0 +1,41 @@
+exports.handler = async (event) => {
+  const apiKey = process.env.FRED_API_KEY;
+  if (!apiKey) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type'
+      },
+      body: JSON.stringify({ error: 'FRED_API_KEY not configured' })
+    };
+  }
+
+  const params = new URLSearchParams(event.queryStringParameters || {});
+  params.set('api_key', apiKey);
+  params.set('file_type', 'json');
+
+  const url = `https://api.stlouisfed.org/fred/series/observations?${params.toString()}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+    return {
+      statusCode: response.ok ? 200 : response.status,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type'
+      },
+      body: JSON.stringify(data)
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type'
+      },
+      body: JSON.stringify({ error: err.message })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a Netlify function that fetches data from FRED using a secret API key
- expose that function at `/api/*` via `netlify.toml`
- remove client-side key and update `fetchMarketData`
- document proxy deployment steps

## Testing
- `npm test` *(fails: no test specified)*
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_6888f700a5c083318561e58367c90cd8