### PR TITLE
Add FRED API helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ The proxy lives at `netlify/functions/fred.js` and forwards any query string it 
 2. In **Site settings → Environment variables**, add `FRED_API_KEY` with your FRED key.
 3. Deploy the site. Requests to `/api/fred` will be served by the function defined in `netlify/functions/fred.js`.
 
+### FRED API script
+
+For local experimentation the `fred_api.py` helper fetches series observations directly from FRED:
+
+```bash
+export FRED_API_KEY=your_key
+python fred_api.py
+```
+
 
 # bank-cre-exposure
 

--- a/fred_api.py
+++ b/fred_api.py
@@ -1,0 +1,57 @@
+import logging
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+FRED_BASE_URL = "https://api.stlouisfed.org/fred"
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_series_observations(
+    series_id: str,
+    api_key: str,
+    params: Optional[Dict[str, Any]] = None,
+    max_retries: int = 3,
+    backoff: float = 1.0,
+) -> Any:
+    """Fetch observations for a FRED series.
+
+    Builds a request to the `/series/observations` endpoint with the provided
+    `series_id` and `api_key`. Additional parameters can be supplied via
+    `params` and default to `file_type=json`.
+    """
+    url = f"{FRED_BASE_URL}/series/observations"
+    query: Dict[str, Any] = {
+        "series_id": series_id,
+        "api_key": api_key,
+        "file_type": "json",
+    }
+    if params:
+        query.update(params)
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            resp = requests.get(url, params=query, timeout=30)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as exc:
+            logging.warning(
+                "Request to %s failed on attempt %d/%d: %s", url, attempt, max_retries, exc
+            )
+            if attempt == max_retries:
+                raise
+            time.sleep(backoff * attempt)
+
+
+if __name__ == "__main__":
+    import os
+
+    series = os.environ.get("FRED_SERIES", "DGS10")
+    api_key = os.environ.get("FRED_API_KEY", "your_key")
+    try:
+        data = get_series_observations(series, api_key)
+        logging.info("Fetched %d observations", len(data.get("observations", [])))
+    except Exception as exc:  # pragma: no cover - example usage
+        logging.error("Failed to fetch series %s: %s", series, exc)

--- a/test_fred_api.py
+++ b/test_fred_api.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from fred_api import FRED_BASE_URL, get_series_observations
+
+
+class TestFredAPI(unittest.TestCase):
+    @patch("fred_api.requests.get")
+    def test_get_series_observations(self, mock_get: Mock) -> None:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"observations": []}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        result = get_series_observations("GDP", "key", params={"frequency": "q"})
+
+        expected_url = f"{FRED_BASE_URL}/series/observations"
+        mock_get.assert_called_with(
+            expected_url,
+            params={
+                "series_id": "GDP",
+                "api_key": "key",
+                "file_type": "json",
+                "frequency": "q",
+            },
+            timeout=30,
+        )
+        self.assertEqual(result, {"observations": []})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `fred_api.py` to query FRED series observations with retries
- document FRED helper usage in README
- test FRED helper request formation and JSON parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689248dc903c8331a43d7f353e3fc56d