### PR TITLE
Use https.request for FRED Netlify function

### DIFF
--- a/netlify/functions/fred.js
+++ b/netlify/functions/fred.js
@@ -1,3 +1,5 @@
+const https = require('https');
+
 exports.handler = async (event) => {
   const apiKey = process.env.FRED_API_KEY;
   if (!apiKey) {
@@ -15,27 +17,61 @@ exports.handler = async (event) => {
   params.set('api_key', apiKey);
   params.set('file_type', 'json');
 
-  const url = `https://api.stlouisfed.org/fred/series/observations?${params.toString()}`;
+  const queryString = params.toString();
+  const path = `/fred/series/observations?${queryString}`;
 
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-    return {
-      statusCode: response.ok ? 200 : response.status,
+  return new Promise((resolve) => {
+    const options = {
+      hostname: 'api.stlouisfed.org',
+      port: 443,
+      path: path,
+      method: 'GET',
       headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'Content-Type'
-      },
-      body: JSON.stringify(data)
+        'User-Agent': 'Mozilla/5.0'
+      }
     };
-  } catch (err) {
-    return {
-      statusCode: 500,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'Content-Type'
-      },
-      body: JSON.stringify({ error: err.message })
-    };
-  }
+
+    const req = https.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        let responseBody;
+        try {
+          responseBody = JSON.parse(data);
+        } catch (e) {
+          responseBody = { error: 'Invalid JSON response', rawData: data };
+        }
+
+        resolve({
+          statusCode: res.statusCode,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'Content-Type',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(responseBody)
+        });
+      });
+    });
+
+    req.on('error', (error) => {
+      resolve({
+        statusCode: 500,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type'
+        },
+        body: JSON.stringify({ 
+          error: 'Failed to connect to FRED API',
+          details: error.message 
+        })
+      });
+    });
+
+    req.end();
+  });
 };


### PR DESCRIPTION
## Summary
- refactor FRED serverless function to call the API via Node's `https` module
- add defensive JSON parsing and detailed error responses

## Testing
- `npm run test:ejs`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892535d52a48331a79bbe4aee44e667