### PR TITLE
Add admin settings page

### DIFF
--- a/bank-cre-exposure.php
+++ b/bank-cre-exposure.php
@@ -27,3 +27,20 @@ function bce_render_tool() {
     return ob_get_clean();
 }
 add_shortcode('bank_cre_exposure', 'bce_render_tool');
+
+function bce_register_admin_page() {
+    add_menu_page(
+        __('Bank CRE Exposure', 'bank-cre-exposure'),
+        __('Bank CRE Exposure', 'bank-cre-exposure'),
+        'manage_options',
+        'bank-cre-exposure',
+        'bce_render_admin_page',
+        'dashicons-chart-area',
+        100
+    );
+}
+add_action('admin_menu', 'bce_register_admin_page');
+
+function bce_render_admin_page() {
+    include plugin_dir_path(__FILE__) . 'templates/admin-page.php';
+}

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -1,0 +1,10 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap">
+    <h1><?php esc_html_e('Bank CRE Exposure Tool', 'bank-cre-exposure'); ?></h1>
+    <p><?php esc_html_e('Use the shortcode', 'bank-cre-exposure'); ?> <code>[bank_cre_exposure]</code> <?php esc_html_e('to embed the report.', 'bank-cre-exposure'); ?></p>
+</div>
+


### PR DESCRIPTION
## Summary
- Add WordPress admin menu and page for Bank CRE Exposure plugin
- Create admin template displaying shortcode usage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937e2ad384833195ed5125f7b22d38