### PR TITLE
feat: display credential status in admin page

### DIFF
--- a/bank-cre-exposure.php
+++ b/bank-cre-exposure.php
@@ -42,5 +42,18 @@ function bce_register_admin_page() {
 add_action('admin_menu', 'bce_register_admin_page');
 
 function bce_render_admin_page() {
+    $credentials = [
+        'FRED_API_KEY'   => getenv('FRED_API_KEY') ?: get_option('FRED_API_KEY'),
+        'FFIEC_USERNAME' => getenv('FFIEC_USERNAME') ?: get_option('FFIEC_USERNAME'),
+        'FFIEC_PASSWORD' => getenv('FFIEC_PASSWORD') ?: get_option('FFIEC_PASSWORD'),
+        'FFIEC_TOKEN'    => getenv('FFIEC_TOKEN') ?: get_option('FFIEC_TOKEN'),
+    ];
+
+    foreach ($credentials as $name => $value) {
+        if (empty($value)) {
+            error_log("Bank CRE Exposure: missing credential {$name}");
+        }
+    }
+
     include plugin_dir_path(__FILE__) . 'templates/admin-page.php';
 }

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -6,5 +6,23 @@ if (!defined('ABSPATH')) {
 <div class="wrap">
     <h1><?php esc_html_e('Bank CRE Exposure Tool', 'bank-cre-exposure'); ?></h1>
     <p><?php esc_html_e('Use the shortcode', 'bank-cre-exposure'); ?> <code>[bank_cre_exposure]</code> <?php esc_html_e('to embed the report.', 'bank-cre-exposure'); ?></p>
+    <h2><?php esc_html_e('Credential Status', 'bank-cre-exposure'); ?></h2>
+    <ul>
+        <?php foreach ($credentials as $name => $value) : ?>
+            <li>
+                <code><?php echo esc_html($name); ?></code>:
+                <?php if ($value) : ?>
+                    <span class="dashicons dashicons-yes-alt" style="color:green;"></span>
+                    <?php esc_html_e('Present', 'bank-cre-exposure'); ?>
+                <?php else : ?>
+                    <span class="dashicons dashicons-warning" style="color:#dc3232;"></span>
+                    <?php esc_html_e('Missing', 'bank-cre-exposure'); ?>
+                    <a href="https://github.com/RealTreasury/bank-cre-exposure#readme" target="_blank">
+                        <?php esc_html_e('Setup Instructions', 'bank-cre-exposure'); ?>
+                    </a>
+                <?php endif; ?>
+            </li>
+        <?php endforeach; ?>
+    </ul>
 </div>
 


### PR DESCRIPTION
## Summary
- show presence of FRED and FFIEC credentials in plugin admin page
- warn and link to setup instructions when credentials are missing
- log missing credentials for easier debugging

## Testing
- `php -l bank-cre-exposure.php`
- `php -l templates/admin-page.php`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893831093d4833197447694cb9534a4