### PR TITLE
Add admin connectivity tests

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,27 @@
+(function($){
+    function handleTest(action, label){
+        var $results = $('#bce-test-results');
+        $results.text('Testing ' + label + '...');
+        wp.ajax.post(action).done(function(response){
+            var body = response.body;
+            if (typeof body !== 'string'){
+                body = JSON.stringify(body);
+            }
+            $results.text(label + ' success (HTTP ' + response.status + ')\n' + body);
+        }).fail(function(error){
+            var message = (error.responseJSON && (error.responseJSON.data && (error.responseJSON.data.message || error.responseJSON.data))) || error.statusText || 'Unknown error';
+            $results.text(label + ' error: ' + message);
+        });
+    }
+
+    $(function(){
+        $('#bce-test-netlify').on('click', function(e){
+            e.preventDefault();
+            handleTest('bce_test_netlify', 'Netlify');
+        });
+        $('#bce-test-ffiec').on('click', function(e){
+            e.preventDefault();
+            handleTest('bce_test_ffiec', 'FFIEC API');
+        });
+    });
+})(jQuery);

--- a/bank-cre-exposure.php
+++ b/bank-cre-exposure.php
@@ -29,7 +29,7 @@ function bce_render_tool() {
 add_shortcode('bank_cre_exposure', 'bce_render_tool');
 
 function bce_register_admin_page() {
-    add_menu_page(
+    $hook = add_menu_page(
         __('Bank CRE Exposure', 'bank-cre-exposure'),
         __('Bank CRE Exposure', 'bank-cre-exposure'),
         'manage_options',
@@ -38,9 +38,88 @@ function bce_register_admin_page() {
         'dashicons-chart-area',
         100
     );
+
+    add_action('admin_print_scripts-' . $hook, 'bce_enqueue_admin_assets');
 }
 add_action('admin_menu', 'bce_register_admin_page');
+
+function bce_enqueue_admin_assets() {
+    wp_enqueue_script(
+        'bce-admin',
+        plugin_dir_url(__FILE__) . 'assets/js/admin.js',
+        ['jquery', 'wp-util'],
+        '1.0.0',
+        true
+    );
+}
 
 function bce_render_admin_page() {
     include plugin_dir_path(__FILE__) . 'templates/admin-page.php';
 }
+
+function bce_test_netlify() {
+    $url = get_option('bce_netlify_url');
+    if (!$url) {
+        $url = getenv('BCE_NETLIFY_URL');
+    }
+    if (!$url) {
+        wp_send_json_error(['message' => 'Netlify URL not configured']);
+    }
+
+    $response = wp_remote_get($url);
+    if (is_wp_error($response)) {
+        wp_send_json_error(['message' => $response->get_error_message()]);
+    }
+
+    $status = wp_remote_retrieve_response_code($response);
+    $body   = wp_remote_retrieve_body($response);
+    $json   = json_decode($body, true);
+
+    wp_send_json_success([
+        'status' => $status,
+        'body'   => $json ? $json : substr($body, 0, 500)
+    ]);
+}
+add_action('wp_ajax_bce_test_netlify', 'bce_test_netlify');
+
+function bce_test_ffiec() {
+    $username = getenv('FFIEC_USERNAME') ?: get_option('ffiec_username');
+    $password = getenv('FFIEC_PASSWORD') ?: get_option('ffiec_password');
+    $token    = getenv('FFIEC_TOKEN') ?: get_option('ffiec_token');
+
+    if (!$username || !$password || !$token) {
+        wp_send_json_error(['message' => 'FFIEC credentials not configured']);
+    }
+
+    $auth = base64_encode($username . ':' . $password . $token);
+    $url  = 'https://cdr.ffiec.gov/public/PWS/UBPR/Search?top=1';
+
+    $response = wp_remote_get($url, [
+        'headers' => [
+            'Authorization' => 'Basic ' . $auth,
+            'Accept'        => 'application/json',
+            'User-Agent'    => 'Mozilla/5.0'
+        ]
+    ]);
+
+    if (is_wp_error($response)) {
+        wp_send_json_error(['message' => $response->get_error_message()]);
+    }
+
+    $status = wp_remote_retrieve_response_code($response);
+    $body   = wp_remote_retrieve_body($response);
+    $json   = json_decode($body, true);
+
+    if (!$json) {
+        wp_send_json_error([
+            'status' => $status,
+            'body'   => substr($body, 0, 500)
+        ]);
+    }
+
+    wp_send_json_success([
+        'status' => $status,
+        'body'   => $json
+    ]);
+}
+add_action('wp_ajax_bce_test_ffiec', 'bce_test_ffiec');

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -6,5 +6,12 @@ if (!defined('ABSPATH')) {
 <div class="wrap">
     <h1><?php esc_html_e('Bank CRE Exposure Tool', 'bank-cre-exposure'); ?></h1>
     <p><?php esc_html_e('Use the shortcode', 'bank-cre-exposure'); ?> <code>[bank_cre_exposure]</code> <?php esc_html_e('to embed the report.', 'bank-cre-exposure'); ?></p>
+    <h2><?php esc_html_e('Connectivity Tests', 'bank-cre-exposure'); ?></h2>
+    <p><?php esc_html_e('Verify connectivity to backend services.', 'bank-cre-exposure'); ?></p>
+    <p>
+        <button id="bce-test-netlify" class="button"><?php esc_html_e('Test Netlify', 'bank-cre-exposure'); ?></button>
+        <button id="bce-test-ffiec" class="button"><?php esc_html_e('Test FFIEC API', 'bank-cre-exposure'); ?></button>
+    </p>
+    <pre id="bce-test-results" style="background:#fff; padding:10px; max-height:300px; overflow:auto;"></pre>
 </div>
 


### PR DESCRIPTION
## Summary
- Add connectivity test section to admin page with Netlify and FFIEC buttons
- Enqueue admin script and AJAX handlers for Netlify and FFIEC checks
- Display test responses with status codes for debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893830daf988331860674ab8d4fc8e5