### PR TITLE
Add admin connectivity test tools

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,24 @@
+(function($){
+    function runTest(action){
+        var $out = $('#bce-test-result');
+        $out.text('Running ' + action + '...');
+        wp.ajax.post(action).done(function(resp){
+            var text = JSON.stringify(resp, null, 2);
+            $out.text('Success:\n' + text);
+        }).fail(function(resp){
+            var data = resp && resp.responseJSON ? resp.responseJSON : resp;
+            var text = JSON.stringify(data, null, 2);
+            $out.text('Error:\n' + text);
+        });
+    }
+    $(function(){
+        $('#bce-test-netlify').on('click', function(e){
+            e.preventDefault();
+            runTest('bce_test_netlify');
+        });
+        $('#bce-test-ffiec').on('click', function(e){
+            e.preventDefault();
+            runTest('bce_test_ffiec');
+        });
+    });
+})(jQuery);

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -24,5 +24,12 @@ if (!defined('ABSPATH')) {
             </li>
         <?php endforeach; ?>
     </ul>
+
+    <h2><?php esc_html_e('Connectivity Tests', 'bank-cre-exposure'); ?></h2>
+    <p>
+        <button id="bce-test-netlify" class="button button-primary"><?php esc_html_e('Test Netlify', 'bank-cre-exposure'); ?></button>
+        <button id="bce-test-ffiec" class="button"><?php esc_html_e('Test FFIEC API', 'bank-cre-exposure'); ?></button>
+    </p>
+    <pre id="bce-test-result" style="background:#fff;border:1px solid #ccc;padding:1em;max-height:300px;overflow:auto;"></pre>
 </div>
 


### PR DESCRIPTION
## Summary
- Add Connectivity Tests section to admin page with Netlify and FFIEC API checks
- Enqueue admin JavaScript and wire AJAX handlers for tests
- Implement Netlify and FFIEC connectivity test endpoints in PHP

## Testing
- `php -l bank-cre-exposure.php`
- `php -l templates/admin-page.php`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893844cb8988331bb5660168c5f90d9