### PR TITLE
Expose Netlify URL to frontend

### DIFF
--- a/bank-cre-exposure.php
+++ b/bank-cre-exposure.php
@@ -17,7 +17,14 @@ function bce_enqueue_assets() {
 add_action('wp_enqueue_scripts', 'bce_enqueue_assets');
 
 function bce_pass_js_vars() {
-    wp_add_inline_script('bce-script', 'window.bce_plugin_url = "' . plugin_dir_url(__FILE__) . '";', 'before');
+    $netlify_url = get_option('BCE_NETLIFY_URL', 'https://stirring-pixie-0b3931.netlify.app');
+
+    $js_vars = "
+        window.bce_plugin_url = '" . plugin_dir_url(__FILE__) . "';
+        window.bce_netlify_url = '" . esc_js($netlify_url) . "';
+    ";
+
+    wp_add_inline_script('bce-script', $js_vars, 'before');
 }
 add_action('wp_enqueue_scripts', 'bce_pass_js_vars');
 


### PR DESCRIPTION
## Summary
- Pass saved Netlify URL and plugin path to frontend JS via inline script.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949f359e0883319685ef44de19641d