### PR TITLE
fix: flag mock data usage as error

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -39,10 +39,11 @@
                 displayBankData(bankData);
                 updateStatistics(bankData);
 
-                const statusMessage = result.isMock
-                    ? `Connected: using fallback data (${bankData.length} records)`
-                    : `Connected to data sources (${bankData.length} records)`;
-                updateAPIStatus('connected', statusMessage);
+                if (result.isMock) {
+                    updateAPIStatus('error', `Using mock data - No live data available`);
+                } else {
+                    updateAPIStatus('connected', `Connected to real data sources (${bankData.length} records)`);
+                }
                 updateLastUpdated();
 
             } catch (error) {


### PR DESCRIPTION
## Summary
- flag mock data usage as an error instead of connected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c3a957308331ae9fd00d6ee3fe92