### PR TITLE
Ensure default Netlify URL for WordPress plugin

### DIFF
--- a/bank-cre-exposure.php
+++ b/bank-cre-exposure.php
@@ -10,6 +10,13 @@
  * Text Domain: bank-cre-exposure
  */
 
+function bce_activate() {
+    if (false === get_option('BCE_NETLIFY_URL')) {
+        add_option('BCE_NETLIFY_URL', 'https://stirring-pixie-0b3931.netlify.app');
+    }
+}
+register_activation_hook(__FILE__, 'bce_activate');
+
 function bce_enqueue_assets() {
     wp_enqueue_style('bce-style', plugin_dir_url(__FILE__) . 'assets/css/style.css', [], '1.0.0');
     wp_enqueue_script('bce-script', plugin_dir_url(__FILE__) . 'assets/js/main.js', [], '1.0.0', true);

--- a/dev/netlify.toml
+++ b/dev/netlify.toml
@@ -4,11 +4,11 @@
 [functions]
   # Increase timeout for slow FFIEC API
   timeout = 60
-  
-  # Node.js version
+
+  # Use esbuild bundler for all functions
   node_bundler = "esbuild"
 
-[functions.ffiec]
+[functions."ffiec"]
   # Specific timeout for the FFIEC function
   timeout = 60
 
@@ -21,7 +21,7 @@
 [[headers]]
   for = "/.netlify/functions/*"
   [headers.values]
-    Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Headers = "Content-Type, Authorization"
-    Access-Control-Allow-Methods = "GET, POST, OPTIONS"
-    Access-Control-Max-Age = "86400"
+    "Access-Control-Allow-Origin" = "*"
+    "Access-Control-Allow-Headers" = "Content-Type, Authorization"
+    "Access-Control-Allow-Methods" = "GET, POST, OPTIONS"
+    "Access-Control-Max-Age" = "86400"

--- a/readme.txt
+++ b/readme.txt
@@ -12,3 +12,7 @@ Visualize and interact with U.S. regional bank CRE exposure. Use shortcode [bank
 == Description ==
 
 This plugin converts the original GitHub Pages project into a WordPress plugin, enqueuing its assets and providing a shortcode.
+
+== Configuration ==
+
+After activating the plugin, visit the **Bank CRE Exposure** settings page in your WordPress admin. The plugin automatically sets the Netlify URL option to `https://stirring-pixie-0b3931.netlify.app` so it points to the correct deployment. Adjust this value if you are using a different Netlify site.


### PR DESCRIPTION
## Summary
- Set `BCE_NETLIFY_URL` option on plugin activation so WordPress admin uses the intended Netlify deployment by default
- Document the Netlify URL configuration in the plugin readme

## Testing
- `php -l bank-cre-exposure.php`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `cd dev && npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_6894afbe2e808331a18a48f6e95836a6