### PR TITLE
fix: correct Netlify configuration

### DIFF
--- a/dev/netlify.toml
+++ b/dev/netlify.toml
@@ -2,14 +2,11 @@
   functions = "netlify/functions"
 
 [functions]
-  # Increase timeout for slow FFIEC API
-  timeout = 60
-
   # Use esbuild bundler for all functions
   node_bundler = "esbuild"
 
-[functions."ffiec"]
-  # Specific timeout for the FFIEC function
+[functions.ffiec]
+  # Increase timeout for the FFIEC function
   timeout = 60
 
 [[redirects]]


### PR DESCRIPTION
## Summary
- remove unsupported global function timeout from netlify.toml
- configure FFIEC function-specific timeout and keep esbuild bundling

## Testing
- `npx @netlify/config --cwd dev`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6894b3ff30ec8331bab53ea9f00abae1