### PR TITLE
Add diagnostic FFIEC API function

### DIFF
--- a/scripts/test_ffiec_credentials.sh
+++ b/scripts/test_ffiec_credentials.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Simple diagnostic script to verify FFIEC credentials.
+# Requires FFIEC_USERNAME, FFIEC_PASSWORD, and FFIEC_TOKEN environment variables.
+
+set -euo pipefail
+
+if [[ -z "${FFIEC_USERNAME:-}" || -z "${FFIEC_PASSWORD:-}" || -z "${FFIEC_TOKEN:-}" ]]; then
+  echo "Missing FFIEC credentials. Please set FFIEC_USERNAME, FFIEC_PASSWORD, and FFIEC_TOKEN."
+  exit 1
+fi
+
+AUTH=$(printf "%s:%s%s" "$FFIEC_USERNAME" "$FFIEC_PASSWORD" "$FFIEC_TOKEN" | base64)
+
+curl -X GET "https://cdr.ffiec.gov/public/PWS/Institution/Find/628" \
+  -H "Authorization: Basic $AUTH" \
+  -H "Accept: application/json"
+


### PR DESCRIPTION
## Summary
- replace FFIEC Netlify function with detailed diagnostic implementation
- add credential check script for FFIEC API

## Testing
- `pytest -q`
- `./scripts/test_ffiec_credentials.sh` *(fails: Missing FFIEC credentials. Please set FFIEC_USERNAME, FFIEC_PASSWORD, and FFIEC_TOKEN.)*

------
https://chatgpt.com/codex/tasks/task_e_689619f49e248331b32a1192a0c7f625