### PR TITLE
feat: quarter picker and period validation

### DIFF
--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -50,8 +50,10 @@ if (!defined('ABSPATH')) {
     <p><?php esc_html_e('Use these tools to diagnose and fix connection issues:', 'bank-cre-exposure'); ?></p>
 
     <div style="margin: 20px 0;">
-        <label for="bce-reporting-period"><?php esc_html_e('Reporting period (last 3 years):', 'bank-cre-exposure'); ?></label>
-        <select id="bce-reporting-period" name="bce-reporting-period"></select>
+        <label for="bce-reporting-period"><strong>Reporting period (last 3 years):</strong></label>
+        <select id="bce-reporting-period" name="bce-reporting-period" class="regular-text">
+            <!-- Options populated by admin.js from Netlify list_periods -->
+        </select>
     </div>
 
     <div style="margin: 20px 0;">


### PR DESCRIPTION
## Summary
- add reporting period dropdown limited to recent quarters in admin UI
- return last 12 periods from FFIEC function, validate ISO input, and auto-fallback on invalid periods
- send ISO reporting_period from admin.js requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963a7d3b448331b5d1efb8a17cadb0