### PR TITLE
Improve mobile performance by lightening styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -415,8 +415,8 @@ body {
         
         /* Footer */
         .report-footer {
-            background: linear-gradient(135deg, 
-                rgba(255, 255, 255, 0.95) 0%, 
+            background: linear-gradient(135deg,
+                rgba(255, 255, 255, 0.95) 0%,
                 rgba(248, 248, 248, 0.98) 100%);
             backdrop-filter: blur(20px) saturate(130%);
             border: 2px solid rgba(199, 125, 255, 0.2);
@@ -426,7 +426,34 @@ body {
             color: var(--gray-text);
             font-size: 0.9rem;
             margin-top: 30px;
-            box-shadow: 
+            box-shadow:
                 0 8px 32px rgba(114, 22, 244, 0.12),
                 inset 0 1px 0 rgba(255, 255, 255, 0.8);
+        }
+
+        /* Mobile performance tweaks */
+        @media (max-width: 600px) {
+            .report-header,
+            .conditions-box,
+            .stat-card,
+            .report-content,
+            .report-footer {
+                backdrop-filter: none;
+                -webkit-backdrop-filter: none;
+                box-shadow: none;
+            }
+
+            .report-header,
+            .report-content,
+            .report-footer {
+                padding: 16px;
+            }
+
+            .stat-number {
+                font-size: 1.8rem;
+            }
+
+            table {
+                min-width: 600px;
+            }
         }


### PR DESCRIPTION
## Summary
- Reduce blur and box-shadow effects on small screens
- Shrink padding and adjust font sizes for phones

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689640e20e6483319e79c2ce9bb3a117