### PR TITLE
Fix FFIEC SOAP calls and drop unused password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,6 @@
 # Username for FFIEC Public Web Service
 FFIEC_USERNAME=your_ffiec_username
-# Password for FFIEC Public Web Service
-FFIEC_PASSWORD=your_ffiec_password
-# Security token appended to FFIEC password
+# Security token for FFIEC Public Web Service (used as password)
 FFIEC_TOKEN=your_ffiec_token
 
 # FRED API key from https://fred.stlouisfed.org

--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ The FFIEC Public Web Service (PWS) API provides access to financial institution 
 **Base URL:** `https://cdr.ffiec.gov/public/PWS`
 
 ### Authentication
-Requires HTTP Basic authentication with username, password, and security token:
-```
-Authorization: Basic <base64(username:password+token)>
-```
+The FFIEC SOAP API uses WS-Security UsernameToken authentication. Supply your
+FFIEC username and security token (used as the password).
 
 ### UBPR Search Endpoint
 ```
@@ -81,8 +79,7 @@ The Netlify Functions in this repo need a few secrets for both local and deploye
 | Variable | Purpose |
 | --- | --- |
 | `FFIEC_USERNAME` | Username for the FFIEC Public Web Service. |
-| `FFIEC_PASSWORD` | Password for the FFIEC Public Web Service. |
-| `FFIEC_TOKEN` | Security token appended to your FFIEC password. |
+| `FFIEC_TOKEN` | Security token for the FFIEC Public Web Service (used as password). |
 
 For local development, copy `.env.example` to `.env`, fill in your values, then run from the `dev/` directory:
 
@@ -96,7 +93,6 @@ To configure the variables in your Netlify site, use the CLI from within `dev/`:
 ```bash
 cd dev
 netlify env:set FFIEC_USERNAME your_username
-netlify env:set FFIEC_PASSWORD your_password
 netlify env:set FFIEC_TOKEN your_token
 ```
 
@@ -161,7 +157,6 @@ The repository includes a small Python helper `scripts/ffiec_api.py` for accessi
 2. Provide your PWS credentials as environment variables:
    ```bash
    export PWS_USERNAME="your_username"
-   export PWS_PASSWORD="your_password"
    export PWS_TOKEN="your_security_token"
    ```
 3. Execute the script:

--- a/dev/test-ffiec-credentials.js
+++ b/dev/test-ffiec-credentials.js
@@ -7,6 +7,7 @@ async function testFFIECCredentials() {
     // Get credentials from environment variables
     const username = process.env.FFIEC_USERNAME;
     const token = process.env.FFIEC_TOKEN;
+    const DATA_SERIES = 'Call';
 
     console.log('=== FFIEC WS-Security Credentials Test ===\n');
 
@@ -60,21 +61,27 @@ async function testFFIECCredentials() {
         console.log('\n📅 Testing: RetrieveReportingPeriods...');
         
         try {
-            const periodsResult = await client.RetrieveReportingPeriodsPromise({});
-            
-            if (periodsResult?.[0]?.RetrieveReportingPeriodsResult?.string) {
+        const periodsResult = await client.RetrieveReportingPeriodsPromise({
+            dataSeries: DATA_SERIES
+        });
+
+        if (periodsResult?.[0]?.RetrieveReportingPeriodsResult?.string) {
                 const periods = periodsResult[0].RetrieveReportingPeriodsResult.string;
                 const periodsArray = Array.isArray(periods) ? periods : [periods];
-                console.log(`✅ Success! Found ${periodsArray.length} reporting periods`);
-                console.log(`   Latest period: ${periodsArray[periodsArray.length - 1]}`);
-                console.log(`   Available periods: ${periodsArray.slice(-3).join(', ')} (last 3)`);
-                
+                const normalized = periodsArray.map(p =>
+                    String(p).trim().replace(/([0-9]{4})[\/-]?([0-9]{2})[\/-]?([0-9]{2})/, '$1-$2-$3')
+                );
+                console.log(`✅ Success! Found ${normalized.length} reporting periods`);
+                console.log(`   Latest period: ${normalized[normalized.length - 1]}`);
+                console.log(`   Available periods: ${normalized.slice(-3).join(', ')} (last 3)`);
+
                 // Test 2: Try to get panel of reporters
                 console.log('\n🏦 Testing: RetrievePanelOfReporters...');
-                const latestPeriod = periodsArray[periodsArray.length - 1];
-                
+                const latestPeriod = normalized[normalized.length - 1];
+
                 const panelResult = await client.RetrievePanelOfReportersPromise({
-                    ReportingPeriod: latestPeriod
+                    dataSeries: DATA_SERIES,
+                    reportingPeriodEndDate: latestPeriod
                 });
 
                 if (panelResult?.[0]?.RetrievePanelOfReportersResult?.FilerIdentification) {

--- a/scripts/ffiec_api.py
+++ b/scripts/ffiec_api.py
@@ -12,13 +12,13 @@ BASE_URL = "https://cdr.ffiec.gov/public/PWS"
 logging.basicConfig(level=logging.INFO)
 
 
-def get_auth_headers(username: str, password: str, token: str) -> Dict[str, str]:
+def get_auth_headers(username: str, token: str) -> Dict[str, str]:
     """Return authentication headers for FFIEC PWS.
 
-    The security token is appended to the password and encoded using HTTP Basic
-    authentication.
+    The security token is used as the password when forming the HTTP Basic
+    authentication string.
     """
-    auth_str = f"{username}:{password}{token}"
+    auth_str = f"{username}:{token}"
     b64 = base64.b64encode(auth_str.encode("utf-8")).decode("ascii")
     return {
         "Authorization": f"Basic {b64}",
@@ -84,10 +84,9 @@ if __name__ == "__main__":
     import os
 
     username = os.environ.get("PWS_USERNAME", "your_username")
-    password = os.environ.get("PWS_PASSWORD", "your_password")
     token = os.environ.get("PWS_TOKEN", "your_token")
 
-    headers = get_auth_headers(username, password, token)
+    headers = get_auth_headers(username, token)
 
     try:
         cert_number = "00000"  # Replace with actual FDIC certificate number

--- a/scripts/test_ffiec_credentials.sh
+++ b/scripts/test_ffiec_credentials.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 # Simple diagnostic script to verify FFIEC credentials.
-# Requires FFIEC_USERNAME, FFIEC_PASSWORD, and FFIEC_TOKEN environment variables.
+# Requires FFIEC_USERNAME and FFIEC_TOKEN environment variables.
 
 set -euo pipefail
 
-if [[ -z "${FFIEC_USERNAME:-}" || -z "${FFIEC_PASSWORD:-}" || -z "${FFIEC_TOKEN:-}" ]]; then
-  echo "Missing FFIEC credentials. Please set FFIEC_USERNAME, FFIEC_PASSWORD, and FFIEC_TOKEN."
+if [[ -z "${FFIEC_USERNAME:-}" || -z "${FFIEC_TOKEN:-}" ]]; then
+  echo "Missing FFIEC credentials. Please set FFIEC_USERNAME and FFIEC_TOKEN."
   exit 1
 fi
 
-AUTH=$(printf "%s:%s%s" "$FFIEC_USERNAME" "$FFIEC_PASSWORD" "$FFIEC_TOKEN" | base64)
-
-curl -X GET "https://cdr.ffiec.gov/public/PWS/Institution/Find/628" \
-  -H "Authorization: Basic $AUTH" \
-  -H "Accept: application/json"
+# Use the Node.js test script which handles WS-Security authentication
+node dev/test-ffiec-credentials.js
 

--- a/templates/admin-page.php
+++ b/templates/admin-page.php
@@ -29,7 +29,6 @@ if (!defined('ABSPATH')) {
             <li><strong>Configure Environment Variables:</strong> In Netlify Dashboard > Site settings > Environment variables, add:
                 <ul style="margin-top: 10px;">
                     <li><code>FFIEC_USERNAME</code> - Your FFIEC Public Web Service username</li>
-                    <li><code>FFIEC_PASSWORD</code> - Your FFIEC Public Web Service password</li>
                     <li><code>FFIEC_TOKEN</code> - Your FFIEC Public Web Service security token</li>
                 </ul>
             </li>
@@ -37,8 +36,8 @@ if (!defined('ABSPATH')) {
                 <ol>
                     <li>Register at <a href="https://cdr.ffiec.gov/public/" target="_blank">FFIEC CDR Public Data Distribution</a></li>
                     <li>Request access to the Public Web Service (PWS) API</li>
-                    <li>Obtain your username, password, and security token</li>
-                    <li>Note: The security token is appended to your password during authentication</li>
+                    <li>Obtain your username and security token</li>
+                    <li>Note: The security token is used as the password during authentication</li>
                 </ol>
             </li>
             <li><strong>Update Netlify URL:</strong> Enter your Netlify site URL above and save</li>
@@ -96,7 +95,7 @@ if (!defined('ABSPATH')) {
         <details>
             <summary style="cursor: pointer; font-weight: bold;">🔑 Credential Issues</summary>
             <ul style="margin-top: 10px;">
-                <li><strong>Missing Credentials:</strong> Add FFIEC_USERNAME, FFIEC_PASSWORD, FFIEC_TOKEN to Netlify environment variables</li>
+                <li><strong>Missing Credentials:</strong> Add FFIEC_USERNAME and FFIEC_TOKEN to Netlify environment variables</li>
                 <li><strong>Invalid Credentials:</strong> Verify your FFIEC account is active and credentials are correct</li>
                 <li><strong>Mock Data Only:</strong> This indicates credentials are missing or invalid</li>
             </ul>

--- a/tests/test_ffiec_api.py
+++ b/tests/test_ffiec_api.py
@@ -9,8 +9,8 @@ from scripts.ffiec_api import get_auth_headers
 
 class TestAuthHeaders(unittest.TestCase):
     def test_get_auth_headers(self):
-        headers = get_auth_headers("user", "pass", "token")
-        expected = base64.b64encode(b"user:passtoken").decode("ascii")
+        headers = get_auth_headers("user", "token")
+        expected = base64.b64encode(b"user:token").decode("ascii")
         self.assertEqual(headers["Authorization"], f"Basic {expected}")
         self.assertEqual(headers["Accept"], "application/json")
 


### PR DESCRIPTION
## Summary
- pass required `dataSeries: 'Call'` to FFIEC SOAP methods and normalize returned periods
- fetch panels using `reportingPeriodEndDate` and handle missing period errors
- remove obsolete `FFIEC_PASSWORD` references from docs and helper scripts

## Testing
- `npm test --prefix dev` *(fails: Error: no test specified)*
- `pytest`
- `node dev/test-ffiec-credentials.js` *(fails: Missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_689644e7078c83318d9f2991e4b1ec2c