### PR TITLE
Use Netlify functions for data and harden FRED fetch

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -130,6 +130,9 @@ async function testNetlify() {
         const netlifyUrl = getNetlifyUrl();
         console.log('Testing Netlify URL:', netlifyUrl);
 
+        // Quick health check to populate reporting periods
+        await populateReportingPeriodDropdown();
+
         // Test basic connectivity first
         const healthUrl = netlifyUrl + '/.netlify/functions/ffiec?test=true';
         console.log('Health check URL:', healthUrl);


### PR DESCRIPTION
## Summary
- replace SOAP front-end with Netlify ffiec function and call FRED via function
- guard DOM updates on FRED fetch
- run FFIEC period check during admin Netlify test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896616c4ef883319fd4dec9121b0d52