### PR TITLE
Route FFIEC requests through Netlify SOAP function

### DIFF
--- a/dev/netlify/functions/ffiec.js
+++ b/dev/netlify/functions/ffiec.js
@@ -1,4 +1,8 @@
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
+
 const axios = require('axios');
+const { parseStringPromise } = require('xml2js');
 
 // Generate last 12 quarter-end dates (newest → oldest)
 function generateQuarterEnds() {
@@ -19,42 +23,27 @@ exports.handler = async (event) => {
   console.log('=== FFIEC FUNCTION START ===');
   console.log('Query params:', event.queryStringParameters);
 
-  const corsHeaders = {
+  const headers = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Allow-Methods': 'GET, OPTIONS',
   };
 
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers: corsHeaders, body: '' };
+    return { statusCode: 204, headers, body: '' };
   }
 
   const params = event.queryStringParameters || {};
-  
-  // Note: The new API doesn't require authentication for public data
-  // But we'll keep the credential check for backward compatibility
   const username = process.env.FFIEC_USERNAME;
   const token = process.env.FFIEC_TOKEN;
-
-  console.log('Environment check:', {
-    hasUsername: !!username,
-    hasToken: !!token,
-  });
 
   // Health check
   if (params.test === 'true') {
     return {
       statusCode: 200,
-      headers: corsHeaders,
+      headers,
       body: JSON.stringify({
-        status: 'CREDENTIALS_AVAILABLE',
-        service: 'FFIEC_PUBLIC_API_V2',
-        endpoint: 'https://api.ffiec.gov/public/v2/ubpr/financials',
-        authMethod: 'None required for public data',
-        env: {
-          hasUsername: !!username,
-          hasToken: !!token,
-        },
+        status: username && token ? 'CREDENTIALS_AVAILABLE' : 'MISSING_CREDENTIALS',
       }),
     };
   }
@@ -64,7 +53,7 @@ exports.handler = async (event) => {
   if ((params.list_periods || '').toString() === 'true') {
     return {
       statusCode: 200,
-      headers: corsHeaders,
+      headers,
       body: JSON.stringify({ periods }),
     };
   }
@@ -74,7 +63,7 @@ exports.handler = async (event) => {
     if (!periods.includes(reportingPeriod)) {
       return {
         statusCode: 400,
-        headers: corsHeaders,
+        headers,
         body: JSON.stringify({
           error: 'INVALID_INPUT',
           message: 'reporting_period must be one of the last 12 valid ISO quarter-end dates',
@@ -86,181 +75,72 @@ exports.handler = async (event) => {
     reportingPeriod = periods[0];
   }
 
-  const limit = parseInt(params.top, 10) || 50;
+  const top = parseInt(params.top, 10) || 100;
+
+  const soapEnvelope = `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <RetrievePanelOfReporters xmlns="http://cdr.ffiec.gov/public/PWS/">
+      <ReportingPeriod>${reportingPeriod}</ReportingPeriod>
+    </RetrievePanelOfReporters>
+  </soap:Body>
+</soap:Envelope>`;
+
+  const auth = Buffer.from(`${username}:${token || ''}`).toString('base64');
 
   try {
-    // Use the new FFIEC public API v2
-    // This API doesn't require authentication for public data
-    const apiUrl = 'https://api.ffiec.gov/public/v2/ubpr/financials';
-    
-    // The new API uses different query parameters
-    // We need to fetch institutions first, then get their UBPR data
-    // For now, let's use a simpler approach - get top institutions by assets
-    
-    // First, let's try to get the institutions list
-    const institutionsUrl = 'https://api.ffiec.gov/public/v2/institutions';
-    
-    console.log('Fetching institutions from:', institutionsUrl);
-    
-    // Try the institutions endpoint
-    const instResponse = await axios.get(institutionsUrl, {
-      params: {
-        limit: limit,
-        reporting_period: reportingPeriod,
-        sort_by: 'total_assets',
-        sort_order: 'desc'
-      },
-      headers: {
-        'Accept': 'application/json',
-      },
-      timeout: 30000,
-      validateStatus: function (status) {
-        // Don't throw on any status, we'll handle it manually
-        return true;
-      }
-    });
-
-    console.log('Institutions response status:', instResponse.status);
-
-    // If institutions endpoint doesn't work, try the financials endpoint directly
-    if (instResponse.status !== 200) {
-      console.log('Institutions endpoint failed, trying financials endpoint...');
-      
-      // The v2 API might use different structure, let's try the financials endpoint
-      const finResponse = await axios.get(apiUrl, {
-        params: {
-          limit: limit,
-          filters: `REPDTE:${reportingPeriod.replace(/-/g, '')}`,
-          format: 'json'
-        },
+    const response = await axios.post(
+      'https://cdr.ffiec.gov/public/PWS/WebServices/RetrievePanelOfReporters.asmx',
+      soapEnvelope,
+      {
         headers: {
-          'Accept': 'application/json',
+          'Content-Type': 'text/xml; charset=utf-8',
+          SOAPAction: 'http://cdr.ffiec.gov/public/PWS/RetrievePanelOfReporters',
+          Authorization: `Basic ${auth}`,
         },
         timeout: 30000,
-        validateStatus: function (status) {
-          return true;
-        }
-      });
-
-      console.log('Financials response status:', finResponse.status);
-
-      if (finResponse.status !== 200) {
-        // If both endpoints fail, return mock data for testing
-        // This allows the WordPress plugin to continue functioning
-        console.log('Both API endpoints failed, returning mock data...');
-        
-        const mockData = [];
-        for (let i = 1; i <= Math.min(limit, 10); i++) {
-          mockData.push({
-            bank_name: `Test Bank ${i}`,
-            total_assets: Math.floor(Math.random() * 900000000) + 100000000,
-            net_loans_assets: 65 + Math.random() * 20,
-            noncurrent_assets_pct: Math.random() * 3,
-            cd_to_tier1: 50 + Math.random() * 150,
-            cre_to_tier1: 200 + Math.random() * 300,
-          });
-        }
-
-        return {
-          statusCode: 200,
-          headers: corsHeaders,
-          body: JSON.stringify({
-            data: mockData,
-            _meta: {
-              source: 'mock_data_api_unavailable',
-              recordCount: mockData.length,
-              reportingPeriod,
-              timestamp: new Date().toISOString(),
-              note: 'FFIEC API endpoints returned errors. Using mock data for testing.',
-            },
-          }),
-        };
       }
+    );
 
-      // Try to parse the financials response
-      const data = finResponse.data;
-      
-      // Transform the data to match expected format
-      const transformedData = Array.isArray(data) ? data : (data.data || []);
-      
-      return {
-        statusCode: 200,
-        headers: corsHeaders,
-        body: JSON.stringify({
-          data: transformedData,
-          _meta: {
-            source: 'ffiec_v2_api_financials',
-            recordCount: transformedData.length,
-            reportingPeriod,
-            timestamp: new Date().toISOString(),
-          },
-        }),
-      };
-    }
+    const parsed = await parseStringPromise(response.data, { explicitArray: false });
 
-    // Process institutions response
-    const data = Array.isArray(instResponse.data?.data) ? instResponse.data.data : [];
+    const reporters =
+      parsed?.['soap:Envelope']?.['soap:Body']?.['RetrievePanelOfReportersResponse']?.['RetrievePanelOfReportersResult']?.['diffgr:diffgram']?.['DocumentElement']?.['Reporter'] || [];
+
+    const banksList = Array.isArray(reporters) ? reporters : [reporters].filter(Boolean);
+
+    const limitedBanks = banksList.slice(0, Math.min(top, banksList.length));
+
+    const data = limitedBanks.map((bank, index) => ({
+      bank_name: bank.Name || bank.BankName || `Bank ${index + 1}`,
+      rssd_id: bank.ID_Rssd || bank.RSSD_ID || bank.Id_Rssd || null,
+    }));
 
     return {
       statusCode: 200,
-      headers: corsHeaders,
+      headers,
       body: JSON.stringify({
         data,
         _meta: {
-          source: 'ffiec_v2_api_institutions',
+          source: 'ffiec_soap_panel',
           recordCount: data.length,
           reportingPeriod,
           timestamp: new Date().toISOString(),
+          note: 'Real bank names from FFIEC SOAP panel; UBPR metrics not mocked',
         },
       }),
     };
-    
   } catch (error) {
     console.error('FFIEC API Error:', error);
-
-    // If there's a network error, return mock data so the plugin can still function
-    if (error.code === 'ECONNREFUSED' || error.code === 'ETIMEDOUT' || error.code === 'ENOTFOUND') {
-      const mockData = [];
-      for (let i = 1; i <= Math.min(limit, 10); i++) {
-        mockData.push({
-          bank_name: `Test Bank ${i}`,
-          total_assets: Math.floor(Math.random() * 900000000) + 100000000,
-          net_loans_assets: 65 + Math.random() * 20,
-          noncurrent_assets_pct: Math.random() * 3,
-          cd_to_tier1: 50 + Math.random() * 150,
-          cre_to_tier1: 200 + Math.random() * 300,
-        });
-      }
-
-      return {
-        statusCode: 200,
-        headers: corsHeaders,
-        body: JSON.stringify({
-          data: mockData,
-          _meta: {
-            source: 'mock_data_network_error',
-            recordCount: mockData.length,
-            reportingPeriod,
-            timestamp: new Date().toISOString(),
-            note: 'Network error connecting to FFIEC API. Using mock data for testing.',
-            error: error.message,
-          },
-        }),
-      };
-    }
-
-    const status = error.response?.status || 500;
-    const message = error.response?.data?.message || error.message;
-
     return {
-      statusCode: status,
-      headers: corsHeaders,
+      statusCode: 502,
+      headers,
       body: JSON.stringify({
         error: 'FFIEC_API_ERROR',
-        message,
+        message: error.message,
         timestamp: new Date().toISOString(),
-        details: error.response?.data || null,
       }),
     };
   }
 };
+


### PR DESCRIPTION
## Summary
- Switch FFIEC Netlify function to SOAP panel endpoint with IPv4 DNS and remove mock fallbacks
- Make browser fetch data through Netlify function and render bank/RSSD rows safely

## Testing
- `python -m pytest -q`
- `cd dev && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896660e59dc8331abc2931c99374016