### PR TITLE
Route FRED requests through Netlify and add redirect

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -37,13 +37,20 @@ async function loadBanksViaNetlify() {
 
 async function fetchMarketData() {
   try {
-    const r = await fetch('/.netlify/functions/fred?series_id=DGS10&limit=30&sort_order=desc');
+    const netlify = (window.bce_data && window.bce_data.netlify_url) || '';
+    if (!netlify) throw new Error('Missing Netlify URL (bce_data.netlify_url)');
+
+    const r = await fetch(
+      `${netlify}/.netlify/functions/fred?series_id=DGS10&limit=30&sort_order=desc`,
+      { signal: AbortSignal.timeout(15000) }
+    );
     if (!r.ok) throw new Error('FRED request failed');
     const json = await r.json();
     const observations = json?.observations || [];
     const last = observations[observations.length - 1];
+
     const el = document.getElementById('market10y');
-    if (el && last?.value) el.textContent = last.value;
+    if (el && last?.value != null) el.textContent = last.value;
   } catch (e) {
     console.error('Error fetching market data:', e);
   }

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,12 @@
   # relative to the base directory.
   functions = "netlify/functions"
 
+# Redirect legacy API paths to Netlify functions
+[[redirects]]
+  from = "/api/fred"
+  to = "/.netlify/functions/fred"
+  status = 200
+
 # This section adds the necessary CORS headers to your function responses.
 [[headers]]
   # Apply these headers to all paths under /.netlify/functions/


### PR DESCRIPTION
## Summary
- Fetch FRED market data via the Netlify deployment URL and guard DOM updates
- Redirect `/api/fred` to the corresponding Netlify function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966eeb032c8331bde34f891b1559a7