### PR TITLE
feat: expose total risk capital ratio

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -85,7 +85,7 @@ async function fetchMarketData() {
 }
 
 function renderBanks(banks) {
-  const tbody = document.getElementById('bankTableBody');
+  const tbody = document.getElementById('tableBody');
   if (!tbody) return;
   tbody.innerHTML = '';
   banks.forEach((b, i) => {
@@ -98,6 +98,7 @@ function renderBanks(banks) {
       <td>${b.cd_to_tier1 ?? '—'}</td>
       <td>${b.net_loans_assets ?? '—'}</td>
       <td>${b.noncurrent_assets_pct ?? '—'}</td>
+      <td>${b.total_risk_based_capital_ratio != null ? Number(b.total_risk_based_capital_ratio).toFixed(2) : '—'}</td>
     `;
     tbody.appendChild(tr);
   });

--- a/dev/netlify/functions/ffiec.js
+++ b/dev/netlify/functions/ffiec.js
@@ -214,6 +214,8 @@ exports.handler = async (event) => {
         ...r,
         ubpr_roe: u.ROE ?? null,
         ubpr_nim: u.NIM ?? null,
+        total_risk_based_capital_ratio:
+          u.RBC1 ?? u.TOTRBC ?? u.TOTAL_RISK_BASED_CAPITAL_RATIO ?? null,
       };
     });
     log({ stage: 'count_after_join', rows: filtered.length, ubpr_period_resolved: ubprPeriod });
@@ -227,6 +229,8 @@ exports.handler = async (event) => {
       rssd_id: bank.ID_Rssd || bank.RSSD_ID || bank.Id_Rssd || null,
       ubpr_roe: bank.ubpr_roe ?? null,
       ubpr_nim: bank.ubpr_nim ?? null,
+      total_risk_based_capital_ratio:
+        bank.total_risk_based_capital_ratio ?? null,
     }));
 
     return {

--- a/templates/display-tool.php
+++ b/templates/display-tool.php
@@ -72,6 +72,7 @@
                             <th onclick="sortTable(5)">Non-Curr Assets to Total Assets (%)</th>
                             <th onclick="sortTable(6)">C&D Loans to Tier 1 Cap + Allowance (%)</th>
                             <th onclick="sortTable(7)">CRE Loans to Tier 1 Cap + Allowance (%)</th>
+                            <th onclick="sortTable(8)">Total Risk-Based Capital Ratio (%)</th>
                         </tr>
                     </thead>
                     <tbody id="tableBody">


### PR DESCRIPTION
## Summary
- join UBPR `total_risk_based_capital_ratio` into FFIEC function output
- display total risk-based capital ratio column in WordPress table and frontend JS

## Testing
- `node --test tests/ffiec_function.test.js`
- `python -m pytest tests/`


------
https://chatgpt.com/codex/tasks/task_e_68a11424f8ec83318996e72d05db7beb