### PR TITLE
fix(ubpr): improve live FFIEC calls and extend function timeout

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,9 @@
   # relative to the base directory.
   functions = "netlify/functions"
 
+[functions]
+  timeout = 26
+
 # Redirect legacy API paths to Netlify functions
 [[redirects]]
   from = "/api/fred"


### PR DESCRIPTION
## Summary
- force JSON responses for FFIEC public endpoints and map `top` to `limit`
- request UBPR financials for the latest released period with clearer errors
- extend Netlify function timeout for slower public APIs

## Testing
- `node tests/ffiec_function.test.js`
- `FFIEC_USERNAME=foo FFIEC_TOKEN=bar node dev/test-ffiec-credentials.js` *(fails: Request failed with status code 403)*
- `netlify deploy --prod` *(fails: command not found: netlify)*

------
https://chatgpt.com/codex/tasks/task_e_68a1379b786083319dd6b9492b381ef2