### PR TITLE
Improve sample data warning in admin diagnostics

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -359,10 +359,15 @@ async function updateData() {
 
         let statusMessage = `✅ Data update successful (${recordCount} records)`;
         let statusType = 'success';
-        
+
         // Verify we got real data, not mock
         if (dataSource.includes('real_data')) {
             statusMessage = `✅ Successfully fetched ${recordCount} real bank records`;
+        } else if (dataSource === 'sample_data') {
+            statusType = 'warning';
+            const meta = data._meta || {};
+            const errorInfo = meta.error ? `, error: ${meta.error}` : '';
+            statusMessage = `⚠️ Using sample data (${recordCount} records${errorInfo})`;
         } else {
             statusType = 'warning';
             statusMessage = `⚠️ Data retrieved but source unclear (${recordCount} records, source: ${dataSource})`;


### PR DESCRIPTION
## Summary
- Clarify admin data update status when API fallback uses sample data, including error details

## Testing
- `npm --prefix dev run test:ejs`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a142dbd8688331b381d6890c248b21